### PR TITLE
update to v4.3.x

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,7 +17,7 @@ parts:
     # See 'snapcraft plugins'
     plugin: cmake
     source: https://github.com/qbittorrent/qBittorrent.git
-    source-branch: v4_2_x
+    source-branch: v4_3_x
     source-depth: 1
     cmake-parameters:
       - -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
- Upgrade to 4.3.X release
- Icons are now working due to upstream fixes
- Not using core18/kde-neon extension due to amd64 exclusivity