### PR TITLE
CI: Build on every push

### DIFF
--- a/.github/workflows/build-snap.yaml
+++ b/.github/workflows/build-snap.yaml
@@ -1,0 +1,22 @@
+on:
+  workflow_call:
+    outputs:
+      snap:
+        description: "Built snap output"
+        value: ${{ steps.snapcraft.outputs.snap }}
+  push:
+    branches:
+      - '*'
+      - '!master'
+      - '!github-actions'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: snapcore/action-build@v1
+        id: build
+      - uses: actions/upload-artifact@v2
+        with: 
+          name: snap
+          path: ${{ steps.snapcraft.outputs.snap }}

--- a/.github/workflows/build-snap.yaml
+++ b/.github/workflows/build-snap.yaml
@@ -3,7 +3,7 @@ on:
     outputs:
       snap:
         description: "Built snap output"
-        value: ${{ steps.snapcraft.outputs.snap }}
+        value: ${{ jobs.build.outputs.snap }}
   push:
     branches:
       - '*'
@@ -15,8 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: snapcore/action-build@v1
-        id: build
+        id: snapcraft
       - uses: actions/upload-artifact@v2
         with: 
           name: snap
           path: ${{ steps.snapcraft.outputs.snap }}
+    outputs:
+      snap: ${{ steps.snapcraft.outputs.snap }}

--- a/.github/workflows/deploy-snap.yaml
+++ b/.github/workflows/deploy-snap.yaml
@@ -1,18 +1,21 @@
 on:
   push:
-    branches: 
+    branches:
       - master
       - github-actions
   schedule:
-    - cron: '0 0 * * 2'
-  
+    - cron: "0 0 * * 2"
+
 jobs:
   build:
+    uses: arnatious/qbittorrent-arnatious/.github/workflows/build-snap@github-actions
+  publish:
     runs-on: ubuntu-latest
+    needs: build
     steps:
-      - uses: actions/checkout@v2
-      - uses: snapcore/action-build@v1
-        id: build
+      - uses: actions/download-artifact@v2
+        with:
+          name: snap
       - uses: snapcore/action-publish@v1
         with:
           store_login: ${{ secrets.STORE_LOGIN }}

--- a/.github/workflows/deploy-snap.yaml
+++ b/.github/workflows/deploy-snap.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: arnatious/qbittorrent-arnatious/.github/workflows/build-snap@github-actions
+    uses: arnatious/qbittorrent-snap/.github/workflows/build-snap.yaml@github-actions
   publish:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/deploy-snap.yaml
+++ b/.github/workflows/deploy-snap.yaml
@@ -19,5 +19,5 @@ jobs:
       - uses: snapcore/action-publish@v1
         with:
           store_login: ${{ secrets.STORE_LOGIN }}
-          snap: ${{ steps.build.outputs.snap }}
+          snap: ${{ needs.build.outputs.snap }}
           release: edge


### PR DESCRIPTION
New logic - build on all pushes - deploy only from master (or `github-actions` testing branch)