### PR TITLE
update to core22 and qbittorrent v4.6.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: qbittorrent-arnatious # you probably want to 'snapcraft register <name>'
-base: core20 # the base snap is the execution environment for this snap
+base: core22 # the base snap is the execution environment for this snap
 adopt-info: qbittorrent
 summary: A free and lightweight torrent client
 description: |
@@ -13,168 +13,68 @@ grade: stable # must be 'stable' to release into candidate/stable channels
 confinement: strict # use 'strict' once you have the right plugs and slots
 
 architectures:
-  - build-on:
-    - arm64
-    - amd64
+  - amd64
+  - arm64
 
 parts:
   qbittorrent:
     # See 'snapcraft plugins'
     plugin: cmake
     source: https://github.com/qbittorrent/qBittorrent.git
-    source-branch: v4_3_x
+    source-branch: v4_6_x
     cmake-parameters:
       - -DCMAKE_BUILD_TYPE=Release
-      - -DCMAKE_INSTALL_PREFIX=/usr
-      - -DCMAKE_PREFIX_PATH=$SNAPCRAFT_STAGE
+      - -DCMAKE_INSTALL_PREFIX=''
     override-pull: |
-      snapcraftctl pull
-      snapcraftctl set-version $(git describe)
+      craftctl default
+      craftctl set "version=$(git describe | sed 's/^release-//')"
     override-build: |
-      snapcraftctl build
-      sed -i 's|Icon=qbittorrent|Icon=/usr/share/icons/hicolor/192x192/apps/qbittorrent.png|g' $SNAPCRAFT_PART_INSTALL/usr/share/applications/org.qbittorrent.qBittorrent.desktop
+      craftctl default
+      sed 's|^Icon=.*|Icon=${SNAP}/share/icons/hicolor/scalable/apps/qbittorrent.svg|' \
+        -i "$CRAFT_PART_INSTALL/share/applications/org.qbittorrent.qBittorrent.desktop"
     build-packages:
-      - libtool
-      - git
       - zlib1g-dev
-      - libboost-dev
-      - libboost-system-dev
-      - libboost-chrono-dev
-      - libboost-random-dev
       - libssl-dev
-      - libgeoip-dev
-      - pkg-config
-      - libqt5x11extras5-dev
-      - libqt5svg5-dev
-      - libqt5xml5
-      - qtbase5-dev
-      - qttools5-dev
-      - qttools5-dev-tools
-    stage-packages:
-      - python3
-      - libqt5x11extras5
-      - libqt5svg5
-      - qt5-gtk-platformtheme
-      - libqt5concurrent5
-      - libqt5xml5
-      - libcanberra-gtk3-module
+    prime:
+      - bin
+      - share/applications
+      - share/icons/hicolor/scalable/apps
     after:
       - libtorrent
-      - qt5
-    build-environment: &id001
-      - SNAPCRAFT_CMAKE_ARGS: -DCMAKE_FIND_ROOT_PATH=/snap/kde-frameworks-5-qt-5-15-3-core20-sdk/current
 
-  qt5:
-    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
-    source-subdir: qt
-    plugin: make
-    make-parameters: ["FLAVOR=qt5"]
-    build-packages:
-      - qtbase5-dev
-      - dpkg-dev
-    stage-packages:
-      - libxkbcommon0
-      - ttf-ubuntu-font-family
-      - dmz-cursor-theme
-      - light-themes
-      - adwaita-icon-theme
-      - gnome-themes-standard
-      - shared-mime-info
-      - libqt5gui5
-      - libgdk-pixbuf2.0-0
-      - libqt5svg5 # for loading icon themes which are svg
-      - try: [appmenu-qt5] # not available on core18
-      - locales-all
-      - libgtk2.0-0
-    build-environment: *id001
-  qt5-gtk-platform:
-    plugin: nil
-    stage-packages:
-      - qt5-gtk-platformtheme
-    build-environment: *id001
   libtorrent:
     plugin: cmake
     build-packages:
       - build-essential
+      - libboost-dev
+      - libssl-dev
     cmake-parameters:
-      - -DCMAKE_CXX_STANDARD=14
       - -DCMAKE_BUILD_TYPE=Release
       - -DCMAKE_INSTALL_PREFIX=''
+      - -DBUILD_SHARED_LIBS=OFF
     source: https://github.com/arvidn/libtorrent.git
     source-branch: RC_1_2
-    stage-packages:
-      - libboost-system-dev
-    build-environment: *id001
-  kde-neon-extension:
-    build-packages:
-    - g++    
-    build-snaps:
-    - kde-frameworks-5-qt-5-15-3-core20-sdk/latest/candidate
-    make-parameters:
-    - PLATFORM_PLUG=kde-frameworks-5-plug
-    plugin: make
-    source: $SNAPCRAFT_EXTENSIONS_DIR/desktop
-    source-subdir: kde-neon
-layout:
-  /usr/share/icons:
-    bind: $SNAP/usr/share/icons
+    prime:
+      - -*
+
 apps:
   qbittorrent:
-    adapter: full
-    command: usr/bin/qbittorrent
-    command-chain:
-      - snap/command-chain/desktop-launch
-    desktop: usr/share/applications/org.qbittorrent.qBittorrent.desktop
+    extensions:
+      - kde-neon
+    command: bin/qbittorrent
+    desktop: share/applications/org.qbittorrent.qBittorrent.desktop
     plugs:
-      - x11
       - home
       - network
       - network-bind
       - removable-media
       - raw-usb
-      - desktop
-      - desktop-legacy
-      - wayland
       - unity7
       - gsettings
       - network-status
       - network-manager
       - network-control
-      - opengl
-    environment:
-      DISABLE_WAYLAND: 1
-      QT_QPA_PLATFORMTHEME: gtk3
 
 plugs:
-  # Support for common GTK themes
-  # https://forum.snapcraft.io/t/how-to-use-the-system-gtk-theme-via-the-gtk-common-themes-snap/6235
-  gsettings: null
-  gtk-3-themes:
-    interface: content
-    target: $SNAP/data-dir/themes
-    default-provider: gtk-common-themes
-  icon-themes:
-    interface: content
-    target: $SNAP/data-dir/icons
-    default-provider: gtk-common-themes
-  sound-themes:
-    interface: content
-    target: $SNAP/data-dir/sounds
-    default-provider: gtk-common-themes
   desktop:
     mount-host-font-cache: false
-  kde-frameworks-5-plug:
-    content: kde-frameworks-5-qt-5-15-3-core20-all
-    default-provider: kde-frameworks-5-qt-5-15-3-core20
-    interface: content
-    target: $SNAP/kf5
-assumes:
-  - snapd2.43
-environment:
-  SNAP_DESKTOP_RUNTIME: $SNAP/kf5
-hooks:
-  configure:
-    command-chain:
-    - snap/command-chain/hooks-configure-desktop
-    plugs:
-    - desktop


### PR DESCRIPTION
The `kde-neon` extension is used here. I'm not entirely sure it is acceptable.
But the snap size has decreased to 12 MB.