### PR TITLE
Strip the qbittorrent executable

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,6 +24,7 @@ parts:
     source-branch: v4_6_x
     cmake-parameters:
       - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_EXE_LINKER_FLAGS_RELEASE=-s
       - -DCMAKE_INSTALL_PREFIX=''
     override-pull: |
       craftctl default


### PR DESCRIPTION
Usually, executable files in snaps are stripped. In qbittorrent case stripping decreases snap size by about 0.5 MiB.